### PR TITLE
Issue #12 "Accès à l'API avec couple "login:pwd" en dur " corrigé

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,6 +2,10 @@
 <configuration>
     <configSections>
     </configSections>
+	<connectionStrings>
+		<add name="MediaTekDocuments.Properties.Settings.MediaTekDocumentsAuthentificationStrings"
+            connectionString="admin:adminpwd"/>
+	</connectionStrings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -20,6 +20,10 @@ namespace MediaTekDocuments.dal
         /// </summary>
         private static readonly string uriApi = "http://localhost/rest_mediatekdocuments/";
         /// <summary>
+        /// nom de la propriété lié aux str d'authentification vers l'API
+        /// </summary>
+        private static readonly string authentificationName = "MediaTekDocuments.Properties.Settings.MediaTekDocumentsAuthentificationStrings";
+        /// <summary>
         /// instance unique de la classe
         /// </summary>
         private static Access instance = null;
@@ -49,7 +53,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = GetAuthStringByName(authentificationName);
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)
@@ -57,6 +61,20 @@ namespace MediaTekDocuments.dal
                 Console.WriteLine(e.Message);
                 Environment.Exit(0);
             }
+        }
+
+        /// <summary>
+        /// Récupération de la chaîne d'authentification à l'API Rest
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        static string GetAuthStringByName(string name)
+        {
+            string returnValue = null;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings != null)
+                returnValue = settings.ConnectionString;
+            return returnValue;
         }
 
         /// <summary>


### PR DESCRIPTION
L'authentification en dur n'est désormais plus présente , elle a était déplacé dans le fichier App.config, la classe Access.cs récupère la chaîne d'authentification authenticationString avec l'aide de la fonction GetAuthStringByName().